### PR TITLE
Pass on encoding knowledge in HTTP layer to Beautiful Soup

### DIFF
--- a/robobrowser/browser.py
+++ b/robobrowser/browser.py
@@ -38,6 +38,7 @@ class RoboState(object):
         return BeautifulSoup(
             self.response.content,
             features=self.browser.parser,
+            from_encoding=self.response.encoding,
         )
 
 


### PR DESCRIPTION
Requests's response.encoding has a encoding extracted from the
Content-Type HTTP header. Passing the encoding to the Beautiful
Soup will improve encoding detection in the Beautiful Soup.
The Beautiful Soup tries the encoding at first, then tries an
encoding extracted from the HTML content.

Note that response.encoding is None when encoding is not specified
in the Content-Type header. In that case, behavior of Beautiful Soup
does not change.