### PR TITLE
Fix default retry backoff factor

### DIFF
--- a/robobrowser/browser.py
+++ b/robobrowser/browser.py
@@ -67,7 +67,7 @@ class RoboBrowser(object):
     def __init__(self, session=None, parser=None, user_agent=None,
                  history=True, timeout=None, allow_redirects=True, cache=False,
                  cache_patterns=None, max_age=None, max_count=None, tries=None,
-                 multiplier=None):
+                 multiplier=0):
 
         self.session = session or requests.Session()
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -343,3 +343,12 @@ class TestAllowRedirects(unittest.TestCase):
         assert_true(mock_request.called)
         kwargs = mock_request.mock_calls[0][2]
         assert_true(kwargs.get('allow_redirects') is False)
+
+
+class TestRetry(unittest.TestCase):
+
+    def test_default_backoff_factor_not_none(self):
+        session = RoboBrowser(tries=3).session
+        for protocol in session.adapters:
+            factor = session.adapters[protocol].max_retries.backoff_factor
+            assert_true(factor is not None)


### PR DESCRIPTION
Updated RoboBrowser class to default to a retry multiplier of 0
instead of None. Previously when set to None a TypeError would be
raised in the get_backoff_time method of urllib3's Retry class.

[Resolves #51]